### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "type": "git",
     "url": "https://github.com/Ax-LED/ioBroker.powerfox2"
   },
+  "engines": {
+    "node": ">= 16"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.4",
     "axios": "^1.6.2"


### PR DESCRIPTION
adapter-core 3.x.x is known to fail when installed at node 14 or older. So this adapter requires node 16 or newer.